### PR TITLE
Verify fail if captcha was blank in session or params.

### DIFF
--- a/lib/rucaptcha/controller_helpers.rb
+++ b/lib/rucaptcha/controller_helpers.rb
@@ -18,8 +18,8 @@ module RuCaptcha
     end
 
     def verify_rucaptcha?(resource = nil)
-      params[:_rucaptcha] ||= ''
-      right = params[:_rucaptcha].downcase.strip == session[:_rucaptcha]
+      right = params[:_rucaptcha].present? and session[:_rucaptcha].present? and
+              params[:_rucaptcha].downcase.strip == session[:_rucaptcha]
       if resource && resource.respond_to?(:errors)
         resource.errors.add(:base, t('rucaptcha.invalid')) unless right
       end


### PR DESCRIPTION
有的场景session可能为空，保险起见，应该在参数为空或者session为空时验证失败。