### PR TITLE
当params[:_rucaptcha] 不等于 session[:_rucaptcha]时，right 也为true

### DIFF
--- a/lib/rucaptcha/controller_helpers.rb
+++ b/lib/rucaptcha/controller_helpers.rb
@@ -18,7 +18,7 @@ module RuCaptcha
     end
 
     def verify_rucaptcha?(resource = nil)
-      right = params[:_rucaptcha].present? and session[:_rucaptcha].present? and
+      right = params[:_rucaptcha].present? && session[:_rucaptcha].present? &&
               params[:_rucaptcha].downcase.strip == session[:_rucaptcha]
       if resource && resource.respond_to?(:errors)
         resource.errors.add(:base, t('rucaptcha.invalid')) unless right


### PR DESCRIPTION
在`2.2.0p0`版本中，`&&` 与 `and` 的优先级不同。
`right = true && false`
`right = true and false`
的结果不一样