### PR TITLE
Optimize captcha verify

### DIFF
--- a/lib/rucaptcha/controller_helpers.rb
+++ b/lib/rucaptcha/controller_helpers.rb
@@ -16,7 +16,7 @@ module RuCaptcha
     def verify_rucaptcha?(resource = nil)
       rucaptcha_at = session[:_rucaptcha_at].to_i
       # Captcha chars in Session expire in 2 minutes
-      if rucaptcha_at.blank? || (Time.now.to_i - rucaptcha_at) > 120
+      if (Time.now.to_i - rucaptcha_at) > 120
         return false
       end
 


### PR DESCRIPTION
No need to check if ```rucaptcha_at``` is blank since ```(Time.now.to_i - 0)``` should always biger than 120