### PR TITLE
Added session[:_rucaptcha] expire time to configuration.

### DIFF
--- a/lib/rucaptcha.rb
+++ b/lib/rucaptcha.rb
@@ -18,6 +18,7 @@ module RuCaptcha
       @config.font_size   = 45
       @config.implode     = 0.4
       @config.cache_limit = 100
+      @config.expires_in  = 2.minutes
       @config
     end
 

--- a/lib/rucaptcha/configuration.rb
+++ b/lib/rucaptcha/configuration.rb
@@ -11,5 +11,7 @@ module RuCaptcha
     # Number of Captcha codes limit
     # set 0 to disable limit and file cache, default: 100
     attr_accessor :cache_limit
+    # session[:_rucaptcha] expire time, default 2 minutes
+    attr_accessor :expires_in
   end
 end

--- a/lib/rucaptcha/controller_helpers.rb
+++ b/lib/rucaptcha/controller_helpers.rb
@@ -16,7 +16,7 @@ module RuCaptcha
     def verify_rucaptcha?(resource = nil)
       rucaptcha_at = session[:_rucaptcha_at].to_i
       # Captcha chars in Session expire in 2 minutes
-      if (Time.now.to_i - rucaptcha_at) > 120
+      if (Time.now.to_i - rucaptcha_at) > RuCaptcha.config.expires_in
         return false
       end
 

--- a/spec/configure_spec.rb
+++ b/spec/configure_spec.rb
@@ -6,6 +6,7 @@ describe RuCaptcha do
       expect(RuCaptcha.config.len).to eq(2)
       expect(RuCaptcha.config.font_size).to eq(48)
       expect(RuCaptcha.config.implode).to eq(0.111)
+      expect(RuCaptcha.config.expires_in).to eq(2.minutes)
     end
   end
 end


### PR DESCRIPTION
网络不好的情况下（比如国内用户访问国外服务器），容易导致验证码一直过期。把过期时间设置为可配置，让各项目根据情况自行决定过期时间。