### PR TITLE
修复 verify_rucaptcha? 方法在过期时间验证失败后不向 resource 中添加 error 信息

### DIFF
--- a/lib/rucaptcha/controller_helpers.rb
+++ b/lib/rucaptcha/controller_helpers.rb
@@ -14,8 +14,11 @@ module RuCaptcha
     end
 
     def verify_rucaptcha?(resource = nil)
-      right = params[:_rucaptcha].present? && session[:_rucaptcha].present? &&
-              (Time.now.to_i - session[:_rucaptcha_at].to_i) < RuCaptcha.config.expires_in &&
+      # Captcha chars in Session default expire in 2 minutes
+      not_expired = (Time.now.to_i - session[:_rucaptcha_at].to_i) < RuCaptcha.config.expires_in
+
+      right = params[:_rucaptcha].present? &&
+              session[:_rucaptcha].present? && not_expired &&
               params[:_rucaptcha].downcase.strip == session[:_rucaptcha]
 
       if resource && resource.respond_to?(:errors)

--- a/lib/rucaptcha/controller_helpers.rb
+++ b/lib/rucaptcha/controller_helpers.rb
@@ -14,14 +14,10 @@ module RuCaptcha
     end
 
     def verify_rucaptcha?(resource = nil)
-      rucaptcha_at = session[:_rucaptcha_at].to_i
-      # Captcha chars in Session expire in 2 minutes
-      if (Time.now.to_i - rucaptcha_at) > RuCaptcha.config.expires_in
-        return false
-      end
-
       right = params[:_rucaptcha].present? && session[:_rucaptcha].present? &&
+              (Time.now.to_i - session[:_rucaptcha_at].to_i) < RuCaptcha.config.expires_in &&
               params[:_rucaptcha].downcase.strip == session[:_rucaptcha]
+
       if resource && resource.respond_to?(:errors)
         resource.errors.add(:base, t('rucaptcha.invalid')) unless right
       end


### PR DESCRIPTION
校验验证码过期时间失败后, 方法会直接 return.
后面的向 resource 中添加 error 的代码不会执行到.