### PR TITLE
GraphicsMagick support

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,14 +33,18 @@ Idea by: https://ruby-china.org/topics/20558#reply4
 
 #### Ubuntu
 
-```
+```bash
 sudo apt-get install imagemagick
+# or
+sudo apt-get install GraphicsMagick
 ```
 
 #### Mac OS X
 
 ```bash
 brew install imagemagick ghostscript
+# or
+brew install GraphicsMagick ghostscript
 ```
 
 ## Usage
@@ -55,6 +59,9 @@ Create `config/initializers/rucaptcha.rb`
 
 ```rb
 RuCaptcha.configure do
+  # Image processor, default image_magick,
+  # allows: [:image_magick, :graphics_magick]
+  self.image_processor = :image_magick
   # Number of chars, default: 4
   self.len = 4
   # Image font size, default: 45

--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ Idea by: https://ruby-china.org/topics/20558#reply4
 ## Requirements
 
 - ImageMagick 6.9+
+- or GraphicsMagick 1.3+
 
 #### Ubuntu
 

--- a/lib/rucaptcha.rb
+++ b/lib/rucaptcha.rb
@@ -14,12 +14,13 @@ module RuCaptcha
     def config
       return @config if defined?(@config)
       @config = Configuration.new
-      @config.len         = 4
-      @config.font_size   = 45
-      @config.implode     = 0.3
-      @config.cache_limit = 100
-      @config.expires_in  = 2.minutes
-      @config.style       = :colorful
+      @config.image_processor = :image_magick
+      @config.len             = 4
+      @config.font_size       = 45
+      @config.implode         = 0.3
+      @config.cache_limit     = 100
+      @config.expires_in      = 2.minutes
+      @config.style           = :colorful
       @config
     end
 

--- a/lib/rucaptcha/captcha.rb
+++ b/lib/rucaptcha/captcha.rb
@@ -95,6 +95,8 @@ module RuCaptcha
           png_file_path = Rails.root.join('tmp', 'cache', "#{code}.png")
           if RuCaptcha.config.image_processor == :image_magick
             command = "convert -size #{size} xc:White -gravity Center -weight 12 -pointsize 20 -annotate 0 \"#{code}\" -trim #{png_file_path}"
+          else
+            command.squish!
           end
           out, err, _st = Open3.capture3(command)
           warn "  RuCaptcha #{err.strip}" if err.present?

--- a/lib/rucaptcha/configuration.rb
+++ b/lib/rucaptcha/configuration.rb
@@ -1,5 +1,8 @@
 module RuCaptcha
   class Configuration
+    # Image processor, default image_magick,
+    # allows: [:image_magick, :graphics_magick]
+    attr_accessor :image_processor
     # Image font size, default 45
     attr_accessor :font_size
     # Number of chars, default 4

--- a/spec/cache_spec.rb
+++ b/spec/cache_spec.rb
@@ -22,5 +22,18 @@ describe RuCaptcha::Cache do
       expect(RuCaptcha::Captcha).to receive(:create).and_return('aabb')
       expect(RuCaptcha::Captcha.create('abcd')).to eq('aabb')
     end
+
+    context 'graphics_magick' do
+      around :each do |example|
+        RuCaptcha.config.image_processor = :graphics_magick
+        example.run
+        RuCaptcha.config.image_processor = :image_magick
+      end
+
+      it 'should work' do
+        expect(RuCaptcha::Captcha).to receive(:create).and_return('aabb')
+        expect(RuCaptcha::Captcha.create('abcd')).to eq('aabb')
+      end
+    end
   end
 end

--- a/spec/configure_spec.rb
+++ b/spec/configure_spec.rb
@@ -3,6 +3,7 @@ require 'spec_helper'
 describe RuCaptcha do
   describe 'normal' do
     it 'should read right config with spec_helper set' do
+      expect(RuCaptcha.config.image_processor).to eq(:image_magick)
       expect(RuCaptcha.config.len).to eq(2)
       expect(RuCaptcha.config.font_size).to eq(48)
       expect(RuCaptcha.config.implode).to eq(0.111)

--- a/spec/controller_helpers_spec.rb
+++ b/spec/controller_helpers_spec.rb
@@ -19,6 +19,20 @@ describe RuCaptcha do
       expect(simple.generate_rucaptcha).not_to be_nil
       expect(simple.session[:_rucaptcha]).to eq('abcd')
     end
+
+    context 'graphics_magick' do
+      around :each do |example|
+        RuCaptcha.config.image_processor = :graphics_magick
+        example.run
+        RuCaptcha.config.image_processor = :image_magick
+      end
+
+      it 'should work with graphics_magick' do
+        expect(RuCaptcha::Captcha).to receive(:random_chars).and_return('abcd')
+        expect(simple.generate_rucaptcha).not_to be_nil
+        expect(simple.session[:_rucaptcha]).to eq('abcd')
+      end
+    end
   end
 
   describe '.verify_rucaptcha?' do


### PR DESCRIPTION
Add image_processor to configure, default :image_magick, allows [:image_magick, :graphics_magick]
```ruby
RuCaptcha.configure do
  # Image processor, default image_magick,
  # allows: [:image_magick, :graphics_magick]
  self.image_processor = :graphics_magick
  # ...
end
```

- ![a0](https://cloud.githubusercontent.com/assets/855678/16678328/90c56804-4510-11e6-964c-e3d0cd1f0117.png) (Generated by ImageMagick)
- ![a1](https://cloud.githubusercontent.com/assets/855678/16678325/8c9dfca0-4510-11e6-937a-cc55a5ffeadc.png) (Generated by GraphicsMagick)