### PR TITLE
rename error key

### DIFF
--- a/lib/rucaptcha/controller_helpers.rb
+++ b/lib/rucaptcha/controller_helpers.rb
@@ -24,7 +24,7 @@ module RuCaptcha
       end
 
       if resource && resource.respond_to?(:errors)
-        resource.errors.add(:base, t('rucaptcha.invalid')) unless valid
+        resource.errors.add(:rucaptcha, t('rucaptcha.invalid')) unless valid
       end
 
       valid


### PR DESCRIPTION
`:base` 这个名字不明确，用 `:rucaptcha` 或许更好一些
