### PR TITLE
fix: ru_captcha.root_url -> ru_captcha.root_path, to avoid generate a http url in  https application.

### DIFF
--- a/lib/rucaptcha/view_helpers.rb
+++ b/lib/rucaptcha/view_helpers.rb
@@ -13,7 +13,7 @@ module RuCaptcha
 
     def rucaptcha_image_tag(opts = {})
       opts[:class] = opts[:class] || 'rucaptcha-image'
-      image_tag(ru_captcha.root_url, opts)
+      image_tag(ru_captcha.root_path, opts)
     end
   end
 end


### PR DESCRIPTION
after accept this change, the `img_tag`
```erb
<%= rucaptcha_image_tag  %>
```
will generate this code
```html
<img alt="Captcha"  class="rucaptcha-image" src="/rucaptcha/">
```