### PR TITLE
Add skip_cache_store_check configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,8 @@ RuCaptcha.configure do
   # 默认：会从 Rails 配置的 cache_store 里面读取相同的配置信息，并尝试用可以运行的方式，用于存储验证码字符
   # 但如果是 [:null_store, :memory_store, :file_store] 之类的，你可以通过下面的配置项单独给 RuCaptcha 配置 cache_store
   self.cache_store = :mem_cache_store
+  # 如果想要 disable cache_store 的 warning，就设置为 true，default false
+  # self.skip_cache_store_check = true
   # Chars length, default: 5, allows: [3 - 7]
   # self.length = 5
   # enable/disable Strikethrough.

--- a/lib/rucaptcha.rb
+++ b/lib/rucaptcha.rb
@@ -20,6 +20,7 @@ module RuCaptcha
       @config.strikethrough = true
       @config.outline       = false
       @config.expires_in    = 2.minutes
+      @config.skip_cache_store_check = false
 
       if Rails.application
         @config.cache_store = Rails.application.config.cache_store

--- a/lib/rucaptcha/configuration.rb
+++ b/lib/rucaptcha/configuration.rb
@@ -13,5 +13,7 @@ module RuCaptcha
     attr_accessor :strikethrough
     # outline style for hard mode, default: false
     attr_accessor :outline
+    # skip_cache_store_check, default: false
+    attr_accessor :skip_cache_store_check
   end
 end

--- a/lib/rucaptcha/engine.rb
+++ b/lib/rucaptcha/engine.rb
@@ -9,7 +9,7 @@ module RuCaptcha
         mount RuCaptcha::Engine => '/rucaptcha'
       end
 
-      RuCaptcha.check_cache_store!
+      RuCaptcha.check_cache_store! unless RuCaptcha.config.skip_cache_store_check
     end
   end
 end


### PR DESCRIPTION
Hi @huacnlee,

Thanks for the great work on rucaptcha, I've submitted issue #59 asking how to skip cache_store from test env.
It's very annoying to have warnings every times I boot the engine, it's better to be a way to switch on/off the warning messages by setting `skip_cache_store_check` as true.

Let me know if you like this idea or not and why. Cheers.