### PR TITLE
add warning when session is invalid

### DIFF
--- a/lib/rucaptcha/controller_helpers.rb
+++ b/lib/rucaptcha/controller_helpers.rb
@@ -9,6 +9,7 @@ module RuCaptcha
     # session key of rucaptcha
     def rucaptcha_sesion_key_key
       session_id = session.respond_to?(:id) ? session.id : session[:session_id]
+      warning_when_session_invalid if session_id.blank?
       ['rucaptcha-session', session_id].join(':')
     end
 
@@ -72,6 +73,13 @@ module RuCaptcha
         resource.errors.add(:base, t('rucaptcha.invalid'))
       end
       false
+    end
+
+    def warning_when_session_invalid
+      Rails.logger.warn "
+        WARNING! The session.id is blank, RuCaptcha can't work properly, please keep session available.
+        More details about this: https://github.com/huacnlee/rucaptcha/pull/66
+      "
     end
   end
 end


### PR DESCRIPTION
Add warning for situation that session is not created. Make it easy for trouble shooting when the captcha  failed to verify  in this situation.

Sometimes, request for some simple pages in your Rails application may not create a session, as the session in Rails is created lazily. It will be created when it is explicitly used, for example:

```erb
<%= csrf_meta_tags %>
```
or
```ruby
# controller layer
session[:some_key] = some_value
```
If not, you can get `#<ActionDispatch::Request::Session:0x7f9b28a670c8 not yet loaded>` when called `session` in controller. And the session key you seted will not exist in broswer.

Rucaptcha use the session to distinguish the user or current captcha. So you need ensure the session is exist, when use Rucaptcha. Otherwise, it will let you in trouble.