### PR TITLE
fix(rucaptcha_input_tag): fix error of helper method 'rucaptcha_input_tag option'

### DIFF
--- a/lib/rucaptcha/controller_helpers.rb
+++ b/lib/rucaptcha/controller_helpers.rb
@@ -35,6 +35,7 @@ module RuCaptcha
     #   verify_rucaptcha?
     #   verify_rucaptcha?(user, keep_session: true)
     #   verify_rucaptcha?(nil, keep_session: true)
+    #   verify_rucaptcha?(nil, captcha: params[:user][:captcha])
     #
     def verify_rucaptcha?(resource = nil, opts = {})
       opts ||= {}
@@ -54,7 +55,7 @@ module RuCaptcha
       end
 
       # Make sure parama have captcha
-      captcha = (params[:_rucaptcha] || '').downcase.strip
+      captcha = (opts[:captcha] || params[:_rucaptcha] || '').downcase.strip
       if captcha.blank?
         return add_rucaptcha_validation_error
       end

--- a/lib/rucaptcha/controller_helpers.rb
+++ b/lib/rucaptcha/controller_helpers.rb
@@ -29,6 +29,8 @@ module RuCaptcha
     # params:
     # resource - [optional] a ActiveModel object, if given will add validation error message to object.
     # :keep_session - if true, RuCaptcha will not delete the captcha code session.
+    # :captcha - if given, the value of it will be used to verify the captcha,
+    #            if do not give or blank, the value of params[:_rucaptcha] will be used to verify the captcha
     #
     # exmaples:
     #

--- a/lib/rucaptcha/version.rb
+++ b/lib/rucaptcha/version.rb
@@ -1,3 +1,3 @@
 module RuCaptcha
-  VERSION = '2.3.1'
+  VERSION = '2.3.2'
 end

--- a/lib/rucaptcha/view_helpers.rb
+++ b/lib/rucaptcha/view_helpers.rb
@@ -6,8 +6,8 @@ module RuCaptcha
       opts[:autocorrect]    = 'off'
       opts[:autocapitalize] = 'off'
       opts[:pattern]        = '[a-zA-Z]*'
-      opts[:maxlength]      = 5
       opts[:autocomplete]   = 'off'
+      opts[:maxlength] ||= 5
       tag(:input, opts)
     end
 


### PR DESCRIPTION
rucaptcha_input_tag 生成的 input 的 maxlength 属性值固定为 5，当配置验证码长度为 6 或者 7 的时候，rucaptcha_input_tag 生成的 input 无法输入 6 到 7 位长度的字负串