### PR TITLE
feat(check-captcha-expired): add helper 'is_expired_rucaptcha?' to ch…

### DIFF
--- a/lib/rucaptcha/controller_helpers.rb
+++ b/lib/rucaptcha/controller_helpers.rb
@@ -4,6 +4,7 @@ module RuCaptcha
 
     included do
       helper_method :verify_rucaptcha?
+      helper_method :is_expired_rucaptcha?
     end
 
     # session key of rucaptcha
@@ -67,6 +68,13 @@ module RuCaptcha
       end
 
       true
+    end
+
+    # check capature is expired or not
+    def is_expired_rucaptcha?
+      store_info = RuCaptcha.cache.read(rucaptcha_sesion_key_key)
+      return true if store_info.blank?
+      (Time.now.to_i - store_info[:time]) > RuCaptcha.config.expires_in
     end
 
     private

--- a/lib/rucaptcha/controller_helpers.rb
+++ b/lib/rucaptcha/controller_helpers.rb
@@ -70,7 +70,7 @@ module RuCaptcha
       true
     end
 
-    # check capature is expired or not
+    # Check capature is expired or not
     def is_expired_rucaptcha?
       store_info = RuCaptcha.cache.read(rucaptcha_sesion_key_key)
       return true if store_info.blank?

--- a/spec/controller_helpers_spec.rb
+++ b/spec/controller_helpers_spec.rb
@@ -110,5 +110,16 @@ describe RuCaptcha do
         expect(simple.verify_rucaptcha?).to eq(false)
       end
     end
+
+    describe 'is expired rucaptcha' do
+      it 'should work' do
+        RuCaptcha.cache.write(simple.rucaptcha_sesion_key_key, {
+          time: Time.now.to_i - 121,
+          code: 'abcd'
+        })
+        simple.params[:_rucaptcha] = 'abcd'
+        expect(simple.is_expired_rucaptcha?).to eq(true)
+      end
+    end
   end
 end


### PR DESCRIPTION
添加 helper 方法 `is_expired_rucaptcha?` 用于判断验证码是否过期：

现在的 `verify_rucaptcha?` 方法，在用户输入错误或者验证码超时两种情况下返回的都是 false，但是有种场景：验证码已经过期，用户填写内容和前端显示的验证码看起来一致，不能明确提示用户是输入错误还是已经过期。所以我添加了 `is_expired_rucaptcha?` 方法，用于判断验证码是否过期。