### PR TITLE
fix: rucaptcha input default maxlength

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,5 @@ build/
 
 # unless supporting rvm < 1.11.0 or doing something fancy, ignore this:
 .rvmrc
+
+.ruby-version

--- a/lib/rucaptcha/view_helpers.rb
+++ b/lib/rucaptcha/view_helpers.rb
@@ -7,7 +7,7 @@ module RuCaptcha
       opts[:autocapitalize] = 'off'
       opts[:pattern]        = '[a-zA-Z]*'
       opts[:autocomplete]   = 'off'
-      opts[:maxlength] ||= 5
+      opts[:maxlength]      = RuCaptcha.config.length
       tag(:input, opts)
     end
 

--- a/spec/view_spec.rb
+++ b/spec/view_spec.rb
@@ -2,10 +2,16 @@ require 'spec_helper'
 
 describe ActionView::Base do
   describe '.rucaptcha_input_tag' do
+    let(:context) { ActionView::LookupContext.new([]) }
+    let(:view) { ActionView::Base.new(context) }
+
     it 'should work' do
-      context = ActionView::LookupContext.new([])
-      view = ActionView::Base.new(context)
       expect(view.respond_to?(:rucaptcha_input_tag)).to eq true
+    end
+
+    it 'input maxlength should equal to RuCaptcha.config.length' do
+      RuCaptcha.config.length += 1
+      expect(view.rucaptcha_input_tag.include?("maxlength=\"#{RuCaptcha.config.length}\"")).to eq true
     end
   end
 end


### PR DESCRIPTION
`rucaptcha_input_tag` 方法的 `maxlength` 默认值应该与实际配置值一致