### PR TITLE
fix: sometimes rucaptcha input fails if rucaptcha_image_tag used multiple times in the same request

### DIFF
--- a/lib/rucaptcha/view_helpers.rb
+++ b/lib/rucaptcha/view_helpers.rb
@@ -12,8 +12,9 @@ module RuCaptcha
     end
 
     def rucaptcha_image_tag(opts = {})
+      @rucaptcha_image_tag__image_path_in_this_request ||= "#{ru_captcha.root_path}?t=#{Time.now.strftime("%s%L")}"
       opts[:class] = opts[:class] || "rucaptcha-image"
-      opts[:src] = "#{ru_captcha.root_path}?t=#{Time.now.strftime("%s%L")}"
+      opts[:src] = @rucaptcha_image_tag__image_path_in_this_request
       opts[:onclick] = "this.src = '#{ru_captcha.root_path}?t=' + Date.now();"
       tag(:img, opts)
     end


### PR DESCRIPTION
…

My previous commit https://github.com/huacnlee/rucaptcha/commit/5c01371daac13d8451272bb2e37e1bdaaceee472 did more harm than use

Before commit 5c01371daac13d8451272bb2e37e1bdaaceee472:
if `rucaptcha_image_tag` function is used in place1, place2, place3
it would generate the same src `ru_captcha.root_path`
and browser would request image only once AND application would set expected code to cache store only once too

After 5c01371daac13d8451272bb2e37e1bdaaceee472:
if `rucaptcha_image_tag` function is used in place1, place2, place3
it would generate the 3 different src `#{ru_captcha.root_path}?t=1111`, `#{ru_captcha.root_path}?t=2222`, `#{ru_captcha.root_path}?t=3333`
and browser would request image 3 times
application would set expected code to cache store 3 times too AND the last code wins

Now:
if `rucaptcha_image_tag` function is used in place1, place2, place3
it would generate the same src `#{ru_captcha.root_path}?t=1111`
and browser would request image once
application would set expected code to cache store once too