### PR TITLE
Allow custom mount path

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,9 @@ RuCaptcha.configure do
 
   # Set the image format, default: png, allows: [jpeg, png, webp]
   # self.format = 'png'
+
+  # Custom mount path, default: '/rucaptcha'
+  # self.mount_path = '/rucaptcha'
 end
 ```
 

--- a/lib/rucaptcha.rb
+++ b/lib/rucaptcha.rb
@@ -31,6 +31,7 @@ module RuCaptcha
       @config.line = true
       @config.noise = true
       @config.format = "png"
+      @config.mount_path = "/rucaptcha"
 
       @config.cache_store = if Rails.application
                               Rails.application.config.cache_store

--- a/lib/rucaptcha/configuration.rb
+++ b/lib/rucaptcha/configuration.rb
@@ -17,5 +17,7 @@ module RuCaptcha
     attr_accessor :format
     # skip_cache_store_check, default: false
     attr_accessor :skip_cache_store_check
+    # custom rucaptcha mount path， default： '/rucaptcha'
+    attr_accessor :mount_path
   end
 end

--- a/lib/rucaptcha/engine.rb
+++ b/lib/rucaptcha/engine.rb
@@ -6,7 +6,7 @@ module RuCaptcha
       # https://github.com/rails/rails/blob/3-2-stable/actionpack/lib/action_dispatch/routing/route_set.rb#L268
       # `app.routes.prepend` start from Rails 3.2 - 5.0
       app.routes.prepend do
-        mount RuCaptcha::Engine => "/rucaptcha"
+        mount RuCaptcha::Engine => RuCaptcha.config.mount_path
       end
 
       RuCaptcha.check_cache_store! unless RuCaptcha.config.skip_cache_store_check


### PR DESCRIPTION
This PR add the ability to custom RuCaptcha's mount path with RuCaptcha.config.mount_path.

In my project, I make a sub project of a domain and mount the project at `/foo`,  and I cannot deploy RuCaptcha to `/rucaptcha`.

With this PR, I can mount it at `/foo/rucaptcha`. And I think maybe some other projects would use this feature.

在我的一个项目中，所有的应用都被要求都部署在 `/foo` 下，所以我希望将 `RuCaptcha` 部署在 `/foo/rucaptcha`。目前的配置文件无法支持这个操作，所以只能通过改 HTTP Server 配置的方式处理，或者 monkey patch (还需要在engine挂载前执行)，都比较复杂。所以，这个 PR 希望通过增加新的配置项 `mount_path` 来更加优雅地实现这个需求。