### PR TITLE
Update README.md - added missing config file property self.difficulty

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,6 @@ RuCaptcha.configure do
 
   # Custom mount path, default: '/rucaptcha'
   # self.mount_path = '/rucaptcha'
-
 end
 ```
 

--- a/README.md
+++ b/README.md
@@ -59,11 +59,16 @@ RuCaptcha.configure do
   # Enable or disable noise, default: false
   # self.noise = false
 
+  # Set the difficulty level, default: 5, allows: [1..10].
+  # Only valid when noise is enabled
+  # self.difficulty = 5 
+
   # Set the image format, default: png, allows: [jpeg, png, webp]
   # self.format = 'png'
 
   # Custom mount path, default: '/rucaptcha'
   # self.mount_path = '/rucaptcha'
+
 end
 ```
 


### PR DESCRIPTION
Added the missing configuration property to your readme file. I accidently found out this property from the https://www.rubydoc.info/gems/rucaptcha/3.2.5/RuCaptcha/Configuration

I have tested this property and this configuration is important for my usecase. I have observed that this works only if noise is enabled otherwise there is no effect of this difficulty property. Correct me if i am wrong.  
 